### PR TITLE
INF-474/feat: Update documentation to use vars.RUNNER_STANDARD

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ on:
 
 jobs:
   claude-review:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_STANDARD }}
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary
- Updates documentation example to use `vars.RUNNER_STANDARD` instead of `ubuntu-latest`
- Part of infrastructure-wide migration to standardise runner variables

## Changes
- README.md: Updated example workflow

## Related
- Linear: INF-474