### PR TITLE
feat: add support for CLAUDE_CODE_OAUTH_TOKEN authentication

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -21,4 +21,8 @@ jobs:
       - name: Run Claude Code Review
         uses: ./
         with:
+          # Option 1: Use API key
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Option 2: Use OAuth token (uncomment to use)
+          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,9 +32,21 @@ jobs:
 
 ## Configuration
 
-Add your `ANTHROPIC_API_KEY` to your repository secrets:
+### Authentication
+
+Choose one authentication method:
+
+**Option 1: API Key (Traditional)**
 1. Go to your repository Settings > Secrets and variables > Actions
 2. Add `ANTHROPIC_API_KEY` with your Anthropic API key
+3. Use in workflow: `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
+
+**Option 2: OAuth Token (Recommended for Claude Code users)**
+1. Go to your repository Settings > Secrets and variables > Actions
+2. Add `CLAUDE_CODE_OAUTH_TOKEN` with your Claude Code OAuth token
+3. Use in workflow: `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`
+
+You only need one authentication method.
 
 ## Action Features
 
@@ -46,12 +58,15 @@ Add your `ANTHROPIC_API_KEY` to your repository secrets:
 
 ## Inputs
 
-- `anthropic_api_key` (required): Your Anthropic API key
+- `anthropic_api_key` (optional): Your Anthropic API key
+- `claude_code_oauth_token` (optional): Your Claude Code OAuth token (alternative to API key)
 - `track_progress` (optional): Enable visual progress tracking comments (default: false)
 - `use_sticky_comment` (optional): Use sticky comments for consistent feedback (default: true)
 - `prompt` (optional): Custom review prompt (replaces default)
 - `extra_prompt` (optional): Additional instructions appended to base prompt
 - `claude_args` (optional): Additional Claude CLI arguments
+
+**Note:** Provide either `anthropic_api_key` or `claude_code_oauth_token`, not both.
 
 ## Repository-Specific Configuration
 
@@ -73,4 +88,19 @@ Add repository-specific review instructions:
       - Test coverage for new features
       - SQLAlchemy best practices
       - Alembic migration naming conventions
+```
+
+## Using OAuth Token
+
+For repositories using Claude Code OAuth authentication:
+
+```yaml
+- name: Run Claude Code Review
+  uses: two-inc/claude-pr-review-action@main
+  with:
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    extra_prompt: |
+
+      ## Repository-Specific Guidelines:
+      ...
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,10 @@ author: 'Two Inc'
 inputs:
   anthropic_api_key:
     description: 'Anthropic API key for Claude'
-    required: true
+    required: false
+  claude_code_oauth_token:
+    description: 'Claude Code OAuth token (alternative to anthropic_api_key)'
+    required: false
   track_progress:
     description: 'Enable visual progress tracking comments'
     required: false
@@ -121,6 +124,7 @@ runs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         track_progress: ${{ inputs.track_progress }}
         use_sticky_comment: ${{ inputs.use_sticky_comment }}
         prompt: |


### PR DESCRIPTION
## Summary

- Add support for `CLAUDE_CODE_OAUTH_TOKEN` as an alternative authentication method to `ANTHROPIC_API_KEY`
- Maintain full backwards compatibility with existing workflows
- Update documentation to explain both authentication options

## Changes

- Make `anthropic_api_key` optional in action.yml
- Add `claude_code_oauth_token` input parameter
- Pass OAuth token to upstream `anthropics/claude-code-action@v1`
- Update README.md with authentication method comparison
- Add OAuth token usage example
- Update example workflow to show both options

## Backwards Compatibility

- All existing workflows using `anthropic_api_key` continue to work unchanged
- Both inputs are optional, allowing gradual migration
- If both are provided, `ANTHROPIC_API_KEY` takes precedence (Claude CLI behaviour)
- No breaking changes to existing configurations

## Test Plan

- [x] Verify action.yml syntax is valid
- [x] Verify README.md formatting is correct
- [x] Verify example workflow syntax is valid
- [ ] Test with API key authentication (existing behaviour)
- [ ] Test with OAuth token authentication (new behaviour)
- [ ] Verify in a real PR that Claude reviews work correctly

🤖 Generated with Claude Sonnet 4.5