### PR TITLE
INF-659/feat: prioritise oauth token in docs and examples

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Run Claude Code Review
         uses: ./
         with:
-          # Option 1: Use API key
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Option 1: Use OAuth token (recommended)
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Option 2: Use OAuth token (uncomment to use)
-          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Option 2: Use API key (legacy)
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -36,15 +36,17 @@ jobs:
 
 Choose one authentication method:
 
-**Option 1: API Key (Traditional)**
-1. Go to your repository Settings > Secrets and variables > Actions
-2. Add `ANTHROPIC_API_KEY` with your Anthropic API key
-3. Use in workflow: `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
-
-**Option 2: OAuth Token (Recommended for Claude Code users)**
+**Option 1: OAuth Token (Recommended)**
 1. Go to your repository Settings > Secrets and variables > Actions
 2. Add `CLAUDE_CODE_OAUTH_TOKEN` with your Claude Code OAuth token
 3. Use in workflow: `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`
+
+OAuth tokens provide better security and can be rotated independently from your API key.
+
+**Option 2: API Key (Legacy)**
+1. Go to your repository Settings > Secrets and variables > Actions
+2. Add `ANTHROPIC_API_KEY` with your Anthropic API key
+3. Use in workflow: `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
 
 You only need one authentication method.
 


### PR DESCRIPTION
prioritise oauth token in documentation and examples

- restructure authentication section with oauth as option 1 (recommended)
- update example workflow to use oauth token by default
- add notes about oauth benefits (security, independent rotation)
- keep api key as option 2 for backwards compatibility

tracking: INF-659