### PR TITLE
INF-216/fix: allow missing default Claude review tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If `CLAUDE_REVIEW_CONFIG` is empty or unset, auto-reviews are disabled entirely.
 | `github_app_private_key` | No | | GitHub App private key for cross-repo access |
 | `prompt` | No | *(built-in review prompt)* | Custom review prompt (replaces default) |
 | `extra_prompt` | No | | Additional instructions appended to base prompt |
-| `claude_args` | No | `--max-turns 10 --allowedTools ...` | Additional Claude CLI arguments |
+| `claude_args` | No | `--max-turns 15 --allowedTools ...` | Additional Claude CLI arguments |
 
 **Note:** Provide either `anthropic_api_key` or `claude_code_oauth_token`, not both.
 

--- a/action.yml
+++ b/action.yml
@@ -196,7 +196,7 @@ inputs:
   claude_args:
     description: 'Additional Claude CLI arguments'
     required: false
-    default: '--max-turns 15 --allowedTools "mcp__github__get_pull_request,mcp__github__get_pull_request_reviews,mcp__github__get_issue_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_review_comments,mcp__github__create_and_submit_pull_request_review,mcp__github__add_issue_comment,Bash(gh api graphql:*),Bash(python *validate_migration*)"'
+    default: '--max-turns 15 --allowedTools "mcp__github__get_pull_request,mcp__github__get_pull_request_reviews,mcp__github__get_issue_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__create_and_submit_pull_request_review,mcp__github__add_issue_comment,mcp__github_inline_comment__create_inline_comment,Write,Bash(cat *),Bash(grep *),Bash(gh api graphql:*),Bash(gh api repos/*),Bash(python *validate_migration*)"'
 
 outputs:
   session_id:


### PR DESCRIPTION
## Summary
- add missing default `allowedTools` entries in `action.yml` that were denied in the infra run ([21925146664](https://github.com/two-inc/infra/actions/runs/21925146664?pr=1852))
- include:
  - `mcp__github__get_pull_request_files`
  - `mcp__github_inline_comment__create_inline_comment`
  - `Write`
  - `Bash(cat *)`
  - `Bash(grep *)`
  - `Bash(gh api repos/*)`
- align README default `claude_args` turn count to `--max-turns 15`

## Validation
- Parsed `action.yml` with Ruby YAML parser
- Confirmed diff only updates default tool allowlist + README default snippet