### PR TITLE
feat: reframe Claude as reviewer assistant, never approves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Single-file action (`action.yml`) - no build step, no JS/TS. Thin passthrough to
 
 ## Plugins
 
-- **Marketplace**: `https://github.com/two-inc/claude-plugins.git` (private, needs org-scoped GitHub token)
+- **Marketplace**: `https://github.com/two-inc/agent-plugins.git` (private, needs org-scoped GitHub token)
 - **Default plugin**: `two-database` - provides Alembic/PostgreSQL migration review via `alembic-postgres-migration-helper` skill and `validate_migration.py` AST-based validation script
 - Plugin names use format `plugin-name` (simple) or `plugin-name@marketplace-name` (explicit)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If `CLAUDE_REVIEW_CONFIG` is empty or unset, auto-reviews are disabled entirely.
 | `use_sticky_comment` | No | `false` | Use sticky comments for consistent feedback |
 | `settings` | No | | Claude Code settings as JSON string or path to settings JSON file |
 | `plugins` | No | | Newline-separated list of Claude Code plugin names to install |
-| `plugin_marketplaces` | No | `https://github.com/two-inc/claude-plugins.git` | Newline-separated list of plugin marketplace Git URLs |
+| `plugin_marketplaces` | No | `https://github.com/two-inc/agent-plugins.git` | Newline-separated list of plugin marketplace Git URLs |
 | `include_fix_links` | No | `true` | Include "Fix this" links in PR review comments |
 | `include_comments_by_actor` | No | | Comma-separated actor usernames to include in comment context |
 | `exclude_comments_by_actor` | No | | Comma-separated actor usernames to exclude from comment context |

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   plugin_marketplaces:
     description: 'Newline-separated list of Claude Code plugin marketplace Git URLs'
     required: false
-    default: 'https://github.com/two-inc/claude-plugins.git'
+    default: 'https://github.com/two-inc/agent-plugins.git'
   include_fix_links:
     description: 'Include Fix this links in PR code review feedback'
     required: false
@@ -131,64 +131,43 @@ inputs:
       5. **Do NOT create a review**: Skip the normal review process entirely
 
       **For Regular PRs**: Follow normal review process with extreme selectivity:
-      1. **MANDATORY - Read ALL existing reviews and comments FIRST**: Use `mcp__github__get_pull_request_review_comments` AND `mcp__github__get_issue_comments` to read ALL existing review comments, threads, and reviews from Claude and other reviewers BEFORE starting anything. Determine:
-         - Has Claude already approved this PR? If so, note this
-         - Has Claude previously requested changes? If so, note the specific concerns raised
-         - What issues have already been flagged by any reviewer?
-      2. **Check if action is needed**: Based on step 1, decide whether to proceed:
-         - If Claude already APPROVED and no significant new commits have been pushed since that approval, **do nothing** - exit without posting
-         - If Claude already APPROVED and new commits have been pushed, review ONLY the new changes
-         - If Claude previously REQUESTED CHANGES, check if all flagged concerns have been addressed in new commits
-         "Significant new commits" means commits that change application code, migrations, API contracts, or configuration. Commits that ONLY change docs, comments, formatting, or CI config are NOT significant enough to warrant re-review
-      3. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
-      4. **Resolve fixed issues**: If any issues Claude previously raised have been fixed, use `Bash(gh api graphql:*)` with resolveReviewThread mutation to resolve those threads
-      5. **Create and submit review**: Use `mcp__github__create_and_submit_pull_request_review`:
-         - Every comment MUST specify `path` (file) and `line` (line number from the diff) to appear inline on the code
-         - If you have NEW critical comments: Submit with event type "COMMENT" and include inline comments. Leave the review `body` empty - all feedback goes in inline comments
-         - If Claude previously requested changes and ALL concerns are now addressed: Submit with event type "APPROVE"
-         - If this is a first review and no critical issues found: Submit with event type "APPROVE"
-         - **NEVER approve if you have any unresolved concerns** - only approve when you are confident there are zero critical issues in the entire PR
-         - **NEVER approve a PR that Claude has already approved** - submitting duplicate approvals adds noise
 
-      **ONLY comment on these critical issues:**
-      - **Security vulnerabilities** (SQL injection, XSS, authentication bypasses, etc.)
-      - **Critical bugs** that will cause runtime failures, data corruption, or crashes
-      - **Memory leaks** or severe performance bottlenecks
-      - **Breaking API changes** that will break existing functionality
-      - **Data loss risks** or unsafe database operations
-      - **Unsafe database migrations** (missing lock timeouts, non-concurrent index creation, backwards-incompatible schema changes, missing NOT VALID on FK constraints, FOR UPDATE SKIP LOCKED)
+      1. **Read existing reviews**: Use `mcp__github__get_pull_request_review_comments` AND `mcp__github__get_issue_comments` to read ALL existing comments from Claude and other reviewers. Note what Claude has already reviewed and what issues anyone has flagged.
+
+      2. **Check if action is needed**:
+         - If Claude already posted a review and no significant new commits since → exit without posting
+         - If significant new commits exist → re-review the full diff (not just new commits — they may interact with earlier changes)
+         - "Significant" = changes to application code, migrations, API contracts, or configuration. Doc/comment/formatting/CI-only commits are not significant
+
+      3. **Get diff**: Use `mcp__github__get_pull_request_diff`
+
+      4. **Resolve fixed issues**: If Claude previously flagged issues that are now fixed, resolve those threads via `resolveReviewThread` mutation
+
+      5. **Submit review** via `mcp__github__create_and_submit_pull_request_review`:
+         - **NEVER use event type "APPROVE" or "REQUEST_CHANGES"** — always use "COMMENT". You assist human reviewers; they make the final approval decision
+         - If you have critical findings: include inline comments and recommend against merging
+         - If all previously flagged issues are addressed: note they're resolved and recommend the PR is ready for human approval
+         - If first review with no critical issues: briefly note no critical issues found
+
+      **ONLY flag these critical issues:**
+      - Security vulnerabilities (SQL injection, XSS, auth bypasses, etc.)
+      - Critical bugs causing runtime failures, data corruption, or crashes
+      - Memory leaks or severe performance bottlenecks
+      - Breaking API changes
+      - Data loss risks or unsafe database operations
+      - Unsafe database migrations (see migration review below)
+
+      Do NOT comment on: style, formatting, naming, subjective preferences, non-critical optimisations, documentation, or code that works but could be "better". When in doubt, don't comment.
 
       **Database Migration Review (Alembic/PostgreSQL)**:
-      If the PR contains Alembic migration files (typically under `alembic/versions/` or `migrations/versions/`), use the `two-database` plugin's `alembic-postgres-migration-helper` skill and validation script to review them.
-      NOTE: The validation script requires the migration file to exist on disk. The consuming workflow must have run `actions/checkout@v4` before this action.
-      1. Read the migration file contents from the diff
-      2. Run the validation script against each migration file: `Bash(python ${CLAUDE_PLUGIN_ROOT}/two-database/scripts/validate_migration.py <migration_file>)`
-      3. Check for: missing lock timeouts on batch updates, non-concurrent index creation, backwards-incompatible changes (column drops/renames without expand-migrate-contract), missing NOT VALID on foreign key constraints, use of FOR UPDATE SKIP LOCKED
-      4. Flag any violations as critical inline comments on the specific migration lines
-
-      **DO NOT comment on:**
-      - Minor style issues or formatting
-      - Subjective code organisation preferences
-      - Non-critical performance optimisations
-      - Minor refactoring suggestions
-      - Documentation improvements
-      - Variable naming (unless genuinely confusing)
-      - Code that works correctly but could be "better"
+      For PRs with Alembic migration files (under `alembic/versions/` or `migrations/versions/`), use the `two-database` plugin's `alembic-postgres-migration-helper` skill and run: `Bash(python ${CLAUDE_PLUGIN_ROOT}/two-database/scripts/validate_migration.py <migration_file>)`
+      Check for: missing lock timeouts, non-concurrent index creation, backwards-incompatible changes without expand-migrate-contract, missing NOT VALID on FK constraints, FOR UPDATE SKIP LOCKED.
 
       **Rules:**
-      - **ALL feedback MUST be inline comments**: Every comment must be attached to a specific file and line number via `mcp__github__create_and_submit_pull_request_review`. NEVER use `mcp__github__add_issue_comment` for regular PR reviews. If you cannot tie feedback to a specific line, do not post it
-      - **NEVER duplicate existing comments**: If Claude or any other reviewer has already mentioned an issue, DO NOT comment on it again
-      - **Always resolve fixed issues**: If you previously raised an issue in an earlier commit and it has been fixed in a follow-up commit, you MUST resolve that thread
-      - **Reply inline to existing threads**: When responding to an existing review conversation, use the GraphQL addPullRequestReviewThreadReply mutation to reply in-thread, not a new top-level comment
-      - **Do nothing if nothing changed**: If Claude already approved and no significant new commits exist, exit without posting anything
-      - **Never approve twice**: If Claude already approved, do not submit another approval
-      - **Approve after fixes**: If Claude previously requested changes and the author has addressed all concerns, resolve the threads and approve
-      - **Only approve with high confidence**: Only approve when you have reviewed the entire diff and are confident there are zero critical issues. If you are uncertain about any part of the code, submit with event type "COMMENT" instead of "APPROVE"
-      - If unsure whether an issue is critical enough, DON'T comment
-      - If unsure whether an issue has already been raised, DON'T comment
+      - All feedback MUST be inline comments with `path` and `line`. Never use `mcp__github__add_issue_comment` for regular PRs. If you can't tie feedback to a specific line, don't post it
+      - Never duplicate a comment already made by Claude or another reviewer
       - Maximum 3 inline comments per PR unless there are genuine security/critical issues
-      - Each comment must identify a specific, actionable problem that risks system stability, security, or data integrity
-      - **Use GitHub suggestion blocks for concrete fixes**: When a comment proposes a specific code change (e.g., "use X instead of Y", "add lock timeout", "fix SQL injection by parameterising"), wrap the corrected code in a ` ```suggestion ` block so the author can apply it with one click. For multi-line replacements, set both `start_line` and `line` on the review comment to cover the full range of lines being replaced. Do NOT use suggestion blocks for general warnings or observations that don't have a single concrete fix (e.g., "this endpoint has no authentication")
+      - Use ` ```suggestion ` blocks when proposing concrete code fixes (set both `start_line` and `line` for multi-line replacements). Don't use suggestion blocks for general warnings without a single concrete fix
   extra_prompt:
     description: 'Additional instructions to append to the base prompt'
     required: false


### PR DESCRIPTION
## Context
claude currently acts as an autonomous reviewer that can approve PRs. it should instead act as an assistant to human reviewers — flagging critical issues and recommending for/against merging, but never formally approving

## Changes
- always use COMMENT event type, never APPROVE or REQUEST_CHANGES
- updated step 1 questions (no more "has Claude approved?")
- updated step 2 decision logic (no more "review ONLY new changes" — always re-review full diff)
- updated step 5 submission logic (all paths use COMMENT)
- collapsed rules section (removed 3 approve-related rules, replaced with single never-approve rule)
- de-duplicated prompt — removed repeated instructions for resolve threads, inline comments, no-duplicate, do-nothing-if-unchanged
- renamed plugin marketplace from `claude-plugins` to `agent-plugins`

## Scope / Non-goals
- no changes to release PR logic
- no changes to tool reference or allowed tools
- no changes to what issues are flagged (critical-only policy unchanged)

## Validation
- grepped for APPROVE — only reference is the "NEVER use APPROVE" rule
- net -21 lines in the prompt section

🤖 Generated with [Claude Code](https://claude.com/claude-code)