### PR TITLE
fix: prevent escaped characters in suggestion blocks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -168,6 +168,7 @@ inputs:
       - Never duplicate a comment already made by Claude or another reviewer
       - Maximum 3 inline comments per PR unless there are genuine security/critical issues
       - Use ` ```suggestion ` blocks when proposing concrete code fixes (set both `start_line` and `line` for multi-line replacements). Don't use suggestion blocks for general warnings without a single concrete fix
+      - **Suggestion block formatting**: When writing suggestion blocks, the comment body must contain raw newlines and unescaped quotes — never use literal `\n` or `\"` escape sequences. The MCP tool handles JSON serialisation; you just provide the plain text content with actual line breaks
   extra_prompt:
     description: 'Additional instructions to append to the base prompt'
     required: false


### PR DESCRIPTION
## Summary
- adds explicit instruction to the review prompt warning Claude not to use literal `\n` or `\"` escape sequences in suggestion block comment bodies
- fixes mangled suggestion blocks like the one in [njord-bank PR #3335](https://github.com/two-inc/njord-bank/pull/3335#discussion_r2826922193) where newlines and quotes were escaped

## Test plan
- [ ] push to branch, point a test workflow at `two-inc/claude-code-reviewer@reviewer-assistant-no-approve`
- [ ] open a test PR with an Alembic migration missing `autocommit_block()` to trigger a suggestion block
- [ ] verify the suggestion block renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)