### PR TITLE
fix: add checkout step to composite action

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Single-file action (`action.yml`) - no build step, no JS/TS. Thin passthrough to
 
 ### Key design decisions
 
-- **No checkout step** - consuming workflows handle `actions/checkout@v4` themselves
+- **Includes checkout step** - the composite action runs `actions/checkout@v4` itself so consuming workflows don't need to. Required because the upstream `claude-code-action` expects a git repo to exist (for `restoreConfigFromBase` security hardening)
 - **Pins to `@v1`** - gets semver-compatible upstream patches automatically
 - **Selective commenting** - prompt is heavily tuned to only flag critical issues (security, bugs, data loss, unsafe migrations). Maximum 3 comments per PR unless genuine security issues
 - **Release PR detection** - auto-detects release PRs and creates summaries instead of reviews

--- a/action.yml
+++ b/action.yml
@@ -192,6 +192,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
     - name: Generate GitHub App token
       id: app-token
       if: ${{ inputs.github_app_id != '' && inputs.github_app_private_key != '' }}


### PR DESCRIPTION
## Summary
- upstream `claude-code-action` now requires a git repo to exist before running — its `restoreConfigFromBase` security hardening runs `git fetch` and `git checkout` to restore trusted config files from the base branch
- without a prior checkout, this fails with `fatal: not a git repository`
- adds `actions/checkout@v4` as the first step in the composite action, fixing all consuming repos at once

## Test plan
- [ ] trigger a review on a test PR in checkout-page and confirm the `restoreConfigFromBase` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)