### PR TITLE
INF-928/feat: enable show_full_output for verbose tool call logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -311,6 +311,7 @@ runs:
         include_comments_by_actor: ${{ inputs.include_comments_by_actor }}
         exclude_comments_by_actor: ${{ inputs.exclude_comments_by_actor }}
         allowed_bots: ${{ inputs.allowed_bots }}
+        show_full_output: true
         prompt: |
           ${{ inputs.prompt }}
 


### PR DESCRIPTION
## Summary

- Enable `show_full_output: true` on the upstream `claude-code-action` to log all tool calls and responses in GitHub Actions logs
- Helps debug turn count and identify which tool calls are consuming turns

## Test plan

- [ ] Trigger a review on any repo and check the Actions log for full tool call output

🤖 Generated with [Claude Code](https://claude.com/claude-code)