### PR TITLE
chore(INF-912): bump deprecated node20 actions to node24 successors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -29,7 +29,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./
         env:

--- a/action.yml
+++ b/action.yml
@@ -196,14 +196,14 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 1
 
     - name: Generate GitHub App token
       id: app-token
       if: ${{ inputs.github_app_id != '' && inputs.github_app_private_key != '' }}
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}


### PR DESCRIPTION
## What

Bumps deprecated node20 GitHub Actions pins to their node24 successors.

GitHub is forcing JavaScript actions onto Node 24 from **2 June 2026** and removing the Node 20 runtime on **16 September 2026**. Each affected action's current major pins `using: node20` in its `action.yml`; this PR bumps to a major that ships `using: node24`.

Org-wide tracker: [INF-912](https://linear.app/tillit/issue/INF-912/nodejs-20-actions-deprecated-in-frontend-actions)
Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Bumps in this repo

- actions/checkout@v4 -> v5
- actions/create-github-app-token@v1 -> v3

## Also

Standardises `.github/dependabot.yml` to group github-actions updates under a single wildcard group, so future bumps land as one consolidated PR.

## Test plan

- [ ] CI green on this PR (the workflows themselves exercise the bumped actions)
