### PR TITLE
chore(INF-1130): add client-id input alongside deprecated app-id

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -36,7 +36,7 @@ jobs:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_app_id: ${{ vars.TWO_INC_APP_ID }}
+          github_app_client_id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
           extra_prompt: |
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_app_id: ${{ vars.TWO_INC_APP_ID }}
+          github_app_client_id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
 ```
 
@@ -105,7 +105,8 @@ If `CLAUDE_REVIEW_CONFIG` is empty or unset, auto-reviews are disabled entirely.
 | `include_fix_links` | No | `true` | Include "Fix this" links in PR review comments |
 | `include_comments_by_actor` | No | | Comma-separated actor usernames to include in comment context |
 | `exclude_comments_by_actor` | No | | Comma-separated actor usernames to exclude from comment context |
-| `github_app_id` | No | | GitHub App ID for cross-repo access (e.g. private plugin marketplaces) |
+| `github_app_client_id` | No | | GitHub App client ID for cross-repo access (e.g. private plugin marketplaces) |
+| `github_app_id` | No | | DEPRECATED — use `github_app_client_id` instead. Numeric GitHub App ID, kept as a backward-compatible alias. |
 | `github_app_private_key` | No | | GitHub App private key for cross-repo access |
 | `prompt` | No | *(built-in review prompt)* | Custom review prompt (replaces default) |
 | `extra_prompt` | No | | Additional instructions appended to base prompt |
@@ -131,7 +132,7 @@ Add repository-specific review instructions via `extra_prompt`:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_app_id: ${{ vars.TWO_INC_APP_ID }}
+          github_app_client_id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
           extra_prompt: |
 

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,10 @@ inputs:
     required: false
     default: 'dependabot,deepsource-autofix'
   github_app_id:
-    description: 'GitHub App ID for generating a token with cross-repo access (e.g. for private plugin marketplaces)'
+    description: 'DEPRECATED: use github_app_client_id instead. Numeric GitHub App ID.'
+    required: false
+  github_app_client_id:
+    description: 'GitHub App client ID (preferred over deprecated github_app_id)'
     required: false
   github_app_private_key:
     description: 'GitHub App private key for generating a token with cross-repo access'
@@ -202,10 +205,11 @@ runs:
 
     - name: Generate GitHub App token
       id: app-token
-      if: ${{ inputs.github_app_id != '' && inputs.github_app_private_key != '' }}
+      if: ${{ (inputs.github_app_client_id != '' || inputs.github_app_id != '') && inputs.github_app_private_key != '' }}
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.github_app_id }}
+        app-id: ${{ inputs.github_app_client_id == '' && inputs.github_app_id || '' }}
+        client-id: ${{ inputs.github_app_client_id }}
         private-key: ${{ inputs.github_app_private_key }}
         owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary

Adds a new `client-id` input to the composite action and to the underlying `actions/create-github-app-token@v3` call. The legacy `app-id` input is preserved as a deprecated alias so existing callers keep working — no breaking change for downstream consumers.

- New `client-id` input (preferred) sources `vars.TWO_INC_APP_CLIENT_ID`
- Existing `app-id` input still accepted (marked deprecated in `inputs:` description)
- Token-action call passes both, with `client-id` taking precedence; falls back to `app-id` only when `client-id` is empty
- Conditional gates (`if: ...`) accept either input
- README / AGENTS.md updated where they reference the inputs

The `app-id` input will be removed in a follow-up once every consumer in the org has migrated.

Linear: https://linear.app/tillit/issue/INF-1130

## Test plan

- [ ] CI green
- [ ] Existing callers (passing `app-id`) continue to work
- [ ] New callers (passing `client-id`) work without deprecation warning from upstream `create-github-app-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
