### PR TITLE
INF-1244/fix: allow two-inc bot actor in default allowed_bots

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
   allowed_bots:
     description: 'Comma-separated list of bot usernames allowed to trigger reviews (use * for all bots)'
     required: false
-    default: 'dependabot,deepsource-autofix'
+    default: 'dependabot,deepsource-autofix,two-inc'
   github_app_id:
     description: 'DEPRECATED: use github_app_client_id instead. Numeric GitHub App ID.'
     required: false


### PR DESCRIPTION
## Summary

Upstream `claude-code-action@v1` rejects bot-initiated workflows unless the actor is in `allowed_bots`. PRs opened by the `two-inc` GitHub App were failing with:

```
Action failed with error: Workflow initiated by non-human actor: two-inc (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Example: https://github.com/two-inc/checkout-api/actions/runs/25986534083/job/76384798344?pr=12051

Adds `two-inc` to the default `allowed_bots` list.

Linear: https://linear.app/tillit/issue/INF-1244

## Test plan
- [ ] Action runs successfully on a PR opened by the two-inc bot